### PR TITLE
Add max supply Hard cap

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,7 +117,7 @@ public:
         nTargetSpacing = 1 * 60; //TSC: 1 minute
         nMaturity = 15;
         nMasternodeCountDrift = 20;
-        nMaxMoneyOut = 18000000000* COIN; //500,000,000
+        nMaxMoneyOut = 18000000000 * COIN;
 
         /** Height or Time Based Activations **/
         nLastPOWBlock = 100;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2117,8 +2117,19 @@ double ConvertBitsToDouble(unsigned int nBits)
     return dDiff;
 }
 
+bool maxSupplyReached()
+{
+    int64_t currentMoneySupply = chainActive.Tip()->nMoneySupply;
+    return currentMoneySupply > Params().MaxMoneyOut();
+}
+
 int64_t GetBlockValue(int nHeight)
 {
+    //Hard cap
+    if (maxSupplyReached()) {
+       return 0;
+    }
+
     int64_t nSubsidy = 0;
 
   //  if (Params().NetworkID() == CBaseChainParams::TESTNET) {

--- a/src/main.h
+++ b/src/main.h
@@ -241,6 +241,8 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue, int nMasternodeCou
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader* pblock, bool fProofOfStake);
 
 bool ActivateBestChain(CValidationState& state, CBlock* pblock = NULL, bool fAlreadyChecked = false);
+
+bool maxSupplyReached();
 CAmount GetBlockValue(int nHeight);
 
 /** Create a new block index entry for a given block hash */


### PR DESCRIPTION
Changes:

* I added a hardcap when max supply is reached, block reward will be 0 - so new coins (and sadly now mining fees) will be produced. I could not enable
"fee only rewards" since I am not used to working with this newer codebase you guys have. But after all this is a lot better than overflowing at 18 Billion Coins!